### PR TITLE
Support more arches

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ var (
 
 	debug bool
 
-	validArches = []string{"x86", "x86_64", "armhf"}
+	validArches = []string{"x86", "x86_64", "armhf", "armv7", "aarch64", "ppc64le", "s390x", "mips64"}
 	validRepos  = []string{"main", "community", "testing"}
 )
 


### PR DESCRIPTION
The `validArches` variable has been extended with the actual list of arches that alpine package repository supports